### PR TITLE
Add confirmation dialogs for deleting; and add duplication buttons

### DIFF
--- a/Common/TextBook.cs
+++ b/Common/TextBook.cs
@@ -54,6 +54,21 @@ namespace JiME
 		{
 			PropertyChanged?.Invoke( this, new PropertyChangedEventArgs( name ) );
 		}
+
+		public TextBookData Clone()
+        {
+			TextBookData book = new TextBookData();
+			book.dataName = "Copy of " + this.dataName;
+			book.triggerName = this.triggerName;
+			book.GUID = Guid.NewGuid();
+			book.isEmpty = this.isEmpty;
+			book.pages = new List<string>();
+			foreach(var page in this.pages)
+            {
+				book.pages.Add(page);
+            }
+			return book;
+        }
 	}
 
 	public class TextBookController

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -218,11 +218,11 @@
 				</Grid.RowDefinitions>
 
 				<Border BorderThickness="0,0,0,0" BorderBrush="Gray" Grid.Row="0">
-					<uc:SidebarListView x:Name="objectivesUC" Margin="5" Title="Objectives" />
+					<uc:SidebarListView x:Name="objectivesUC" Margin="5" Title="Objectives" ShowDuplicateButton="true" />
 				</Border>
 
 				<Border Grid.Row="2" BorderThickness="0,0,0,0" BorderBrush="Gray">
-					<uc:SidebarListView Margin="5" x:Name="interactionsUC" Title="Events" />
+					<uc:SidebarListView Margin="5" x:Name="interactionsUC" Title="Events" ShowDuplicateButton="true"/>
 				</Border>
 
 				<!--<GridSplitter HorizontalAlignment="Stretch" 
@@ -233,7 +233,7 @@
 				</GridSplitter>-->
 
 				<Border BorderThickness="0,0,0,0" BorderBrush="Gray" Grid.Row="4">
-					<uc:SidebarListView x:Name="triggersUC" Margin="5" Title="Triggers" />
+					<uc:SidebarListView x:Name="triggersUC" Margin="5" Title="Triggers" ShowDuplicateButton="true"/>
 				</Border>
 
 

--- a/Models/Interaction Events/BranchInteraction.cs
+++ b/Models/Interaction Events/BranchInteraction.cs
@@ -43,6 +43,20 @@ namespace JiME
 			eventBookData.pages.Add( "" );
 		}
 
+		public BranchInteraction Clone()
+        {
+			BranchInteraction interact = new BranchInteraction("");
+			base.CloneInto(interact);
+			interact.branchTestEvent = this.branchTestEvent;
+			interact.triggerNotSetTrigger = this.triggerNotSetTrigger;
+			interact.triggerTest = this.triggerTest;
+			interact.triggerIsSet = this.triggerIsSet;
+			interact.triggerNotSet = this.triggerNotSet;
+			interact.triggerIsSetTrigger = this.triggerIsSetTrigger;
+			interact.triggerNotSetTrigger = this.triggerNotSetTrigger;
+			return interact;
+        }
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/ConditionalInteraction.cs
+++ b/Models/Interaction Events/ConditionalInteraction.cs
@@ -26,6 +26,19 @@ namespace JiME
 			finishedTrigger = "None";
 		}
 
+		public ConditionalInteraction Clone()
+		{
+			ConditionalInteraction interact = new ConditionalInteraction("");
+			base.CloneInto(interact);
+			interact.finishedTrigger = this.finishedTrigger;
+			interact.triggerList = new ObservableCollection<string>();
+			foreach( string trigger in this.triggerList )
+            {
+				interact.triggerList.Add(trigger);
+            }
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/DecisionInteraction.cs
+++ b/Models/Interaction Events/DecisionInteraction.cs
@@ -58,6 +58,20 @@ namespace JiME
 			choice1Trigger = choice2Trigger = choice3Trigger = "None";
 		}
 
+		public DecisionInteraction Clone()
+		{
+			DecisionInteraction interact = new DecisionInteraction("");
+			base.CloneInto(interact);
+			interact.choice1 = this.choice1;
+			interact.choice2 = this.choice2;
+			interact.choice3 = this.choice3;
+			interact.choice1Trigger = this.choice1Trigger;
+			interact.choice2Trigger = this.choice2Trigger;
+			interact.choice3Trigger = this.choice3Trigger;
+			interact.isThreeChoices = this.isThreeChoices;
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/DialogInteraction.cs
+++ b/Models/Interaction Events/DialogInteraction.cs
@@ -100,6 +100,22 @@ namespace JiME
 			c1Trigger = c2Trigger = c3Trigger = "None";
 		}
 
+		public DialogInteraction Clone()
+		{
+			DialogInteraction interact = new DialogInteraction("");
+			base.CloneInto(interact);
+			interact.choice1 = this.choice1;
+			interact.choice2 = this.choice2;
+			interact.choice3 = this.choice3;
+			interact.c1Trigger = this.c1Trigger;
+			interact.c2Trigger = this.c2Trigger;
+			interact.c3Trigger = this.c3Trigger;
+			interact.c1Text = this.c1Text;
+			interact.c2Text = this.c2Text;
+			interact.c3Text = this.c3Text;
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/InteractionBase.cs
+++ b/Models/Interaction Events/InteractionBase.cs
@@ -12,6 +12,25 @@ namespace JiME
 		PersonType _personType;
 		TerrainType _terrainType;
 
+		public virtual void CloneInto(InteractionBase interact)
+		{
+			interact.GUID = Guid.NewGuid();
+			interact.dataName = "Copy of " + this.dataName;
+			interact.triggerName = this.triggerName;
+			interact.triggerAfterName = this.triggerAfterName;
+			interact.isTokenInteraction = this.isTokenInteraction;
+			interact.loreReward = this.loreReward;
+			interact.xpReward = this.xpReward;
+			interact.threatReward = this.threatReward;
+			interact.tokenType = this.tokenType;
+			interact.personType = this.personType;
+			interact.terrainType = this.terrainType;
+			interact.isEmpty = this.isEmpty;
+			interact.textBookData = this.textBookData.Clone();
+			interact.eventBookData = this.eventBookData.Clone();
+			interact.interactionType = this.interactionType;
+		}
+
 		public string dataName
 		{
 			get { return _dataName; }

--- a/Models/Interaction Events/MultiEventInteraction.cs
+++ b/Models/Interaction Events/MultiEventInteraction.cs
@@ -37,6 +37,25 @@ namespace JiME
 			isSilent = true;
 		}
 
+		public MultiEventInteraction Clone()
+		{
+			MultiEventInteraction interact = new MultiEventInteraction("");
+			base.CloneInto(interact);
+			interact.usingTriggers = this.usingTriggers;
+			interact.isSilent = this.isSilent;
+			interact.eventList = new ObservableCollection<string>();
+			foreach(var item in this.eventList)
+            {
+				interact.eventList.Add( item );
+            }
+			interact.triggerList = new ObservableCollection<string>();
+			foreach (var item in this.triggerList)
+			{
+				interact.triggerList.Add(item);
+			}
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/NoneInteraction.cs
+++ b/Models/Interaction Events/NoneInteraction.cs
@@ -20,5 +20,12 @@ namespace JiME
 			};
 			return empty;
 		}
+
+		public NoneInteraction Clone()
+		{
+			NoneInteraction interact = new NoneInteraction("");
+			base.CloneInto(interact);
+			return interact;
+		}
 	}
 }

--- a/Models/Interaction Events/PersistentInteractionBase.cs
+++ b/Models/Interaction Events/PersistentInteractionBase.cs
@@ -43,5 +43,14 @@ namespace JiME
 			persistentText = "";
 			hasActivated = false;
 		}
+
+		public void CloneInto(PersistentInteractionBase interact)
+		{
+			base.CloneInto( interact);
+			interact.isPersistent = this.isPersistent;
+			interact.persistentText = this.persistentText;
+			interact.hasActivated = this.hasActivated;
+		}
+
 	}
 }

--- a/Models/Interaction Events/PersistentTokenInteraction.cs
+++ b/Models/Interaction Events/PersistentTokenInteraction.cs
@@ -28,6 +28,16 @@ namespace JiME
 			isTokenInteraction = true;
 		}
 
+		public PersistentTokenInteraction Clone()
+		{
+			PersistentTokenInteraction interact = new PersistentTokenInteraction("");
+			base.CloneInto(interact);
+			interact.eventToActivate = this.eventToActivate;
+			interact.alternativeTextTrigger = this.alternativeTextTrigger;
+			interact.alternativeBookData = this.alternativeBookData.Clone();
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/ReplaceTokenInteraction.cs
+++ b/Models/Interaction Events/ReplaceTokenInteraction.cs
@@ -55,5 +55,17 @@ namespace JiME
 			noText = true;
 			replaceWithGUID = Guid.Empty;
 		}
+
+		public ReplaceTokenInteraction Clone()
+		{
+			ReplaceTokenInteraction interact = new ReplaceTokenInteraction("");
+			base.CloneInto(interact);
+			interact.eventToReplace = this.eventToReplace;
+			interact.replaceWithEvent = this.replaceWithEvent;
+			interact.noText = this.noText;
+			interact.replaceWithGUID = this.replaceWithGUID;
+			return interact;
+		}
+
 	}
 }

--- a/Models/Interaction Events/RewardInteraction.cs
+++ b/Models/Interaction Events/RewardInteraction.cs
@@ -45,5 +45,15 @@ namespace JiME
 			eventBookData.pages = new List<string>();
 			eventBookData.pages.Add( "" );
 		}
+
+		public RewardInteraction Clone()
+		{
+			RewardInteraction interact = new RewardInteraction("");
+			base.CloneInto(interact);
+			interact.rewardLore = this.rewardLore;
+			interact.rewardXP = this.rewardXP;
+			interact.rewardThreat = this.rewardThreat;
+			return interact;
+		}
 	}
 }

--- a/Models/Interaction Events/TestInteraction.cs
+++ b/Models/Interaction Events/TestInteraction.cs
@@ -117,6 +117,29 @@ namespace JiME
 			progressBookData.pages.Add( "Default Progress Text.\n\nThis text is shown if the Test is Cumulative and the current value is greater than 0 but less than the Success Value for completion. Use it as a way to indicate progress towards competing the Test." );
 		}
 
+		public TestInteraction Clone()
+		{
+			TestInteraction interact = new TestInteraction("");
+			base.CloneInto(interact);
+			interact.successTrigger = this.successTrigger;
+			interact.failTrigger = this.failTrigger;
+			interact.successValue = this.successValue;
+			interact.isCumulative = this.isCumulative;
+			interact.passFail = this.passFail;
+			interact.testAttribute = this.testAttribute;
+			interact.altTestAttribute = this.altTestAttribute;
+			interact.noAlternate = this.noAlternate;
+			interact.passBookData = this.passBookData.Clone();
+			interact.failBookData = this.failBookData.Clone();
+			interact.progressBookData = this.progressBookData.Clone();
+			interact.rewardXP = this.rewardXP;
+			interact.rewardLore = this.rewardLore;
+			interact.rewardThreat = this.rewardThreat;
+			interact.failThreat = this.failThreat;
+			return interact;
+		}
+
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Interaction Events/TextInteraction.cs
+++ b/Models/Interaction Events/TextInteraction.cs
@@ -7,5 +7,12 @@ namespace JiME
 		public TextInteraction( string name ) : base( name )
 		{
 		}
+
+		public TextInteraction Clone()
+		{
+			TextInteraction interact = new TextInteraction("");
+			base.CloneInto(interact);
+			return interact;
+		}
 	}
 }

--- a/Models/Interaction Events/ThreatInteraction.cs
+++ b/Models/Interaction Events/ThreatInteraction.cs
@@ -65,6 +65,23 @@ namespace JiME
 			monsterCollection = new ObservableCollection<Monster>();
 		}
 
+		public ThreatInteraction Clone()
+		{
+			ThreatInteraction interact = new ThreatInteraction("");
+			base.CloneInto(interact);
+			interact.triggerDefeatedName = this.triggerDefeatedName;
+			interact.includedEnemies = (bool[])this.includedEnemies.Clone();
+			interact.basePoolPoints = this.basePoolPoints;
+			interact.difficultyBias = this.difficultyBias;
+			interact.triggerDefeatedName = this.triggerDefeatedName;
+			interact.monsterCollection = new ObservableCollection<Monster>();
+			foreach(var monster in this.monsterCollection)
+            {
+				interact.monsterCollection.Add(monster.Clone());
+            }
+			return interact;
+		}
+
 		new public void RenameTrigger( string oldName, string newName )
 		{
 			base.RenameTrigger( oldName, newName );

--- a/Models/Monster.cs
+++ b/Models/Monster.cs
@@ -481,6 +481,47 @@ namespace JiME
 			}
 		}
 
+		public Monster Clone()
+		{
+			Monster m = new Monster();
+			m.dataName = this.dataName;
+			m.GUID = Guid.NewGuid();
+			m.bonuses = this.bonuses;
+			m.id = this.id;
+			m.activationsId = this.activationsId;
+			m.count = this.count;
+			m.health = this.health;
+			m.shieldValue = this.shieldValue;
+			m.sorceryValue = this.sorceryValue;
+			m.moveA = this.moveA;
+			m.moveB = this.moveB;
+			m.groupLimit = this.groupLimit;
+			m.figureLimit = this.figureLimit;
+			m.damage = this.damage;
+			m.loreReward = this.loreReward;
+			m.movementValue = this.movementValue;
+			m.maxMovementValue = this.maxMovementValue;
+			m.isRanged = this.isRanged;
+			m.isFearsome = this.isFearsome;
+			m.isLarge = this.isLarge;
+			m.isBloodThirsty = this.isBloodThirsty;
+			m.isArmored = this.isArmored;
+			m.isElite = this.isElite;
+			m.defaultStats = this.defaultStats;
+			m.isEasy = this.isEasy;
+			m.isNormal = this.isNormal;
+			m.isHard = this.isHard;
+			m.cost = (int[])this.cost.Clone();
+			m.moveSpecial = (string[])this.moveSpecial.Clone();
+			m.tag = (string[])this.tag.Clone();
+			m.special = (string[])this.special.Clone();
+			m.isEmpty = this.isEmpty;
+			m.triggerName = this.triggerName;
+			m.negatedBy = this.negatedBy;
+			m.monsterType = this.monsterType;
+			return m;
+		}
+
 		public void NotifyPropertyChanged( string propName )
 		{
 			PropertyChanged?.Invoke( this, new PropertyChangedEventArgs( propName ) );

--- a/Models/Objective.cs
+++ b/Models/Objective.cs
@@ -149,6 +149,24 @@ namespace JiME
 			return obj;
 		}
 
+		public Objective Clone()
+		{
+			Objective obj = new Objective("Copy of " + this.dataName);
+			obj.eventName = this.eventName;
+			obj.triggerName = this.triggerName;
+			obj.objectiveReminder = this.objectiveReminder;
+			obj.nextTrigger = this.nextTrigger;
+			obj.triggeredByName = this.triggeredByName;
+			obj.skipSummary = this.skipSummary;
+			obj.loreReward = this.loreReward;
+			obj.xpReward = this.xpReward;
+			obj.threatReward = this.threatReward;
+			obj.GUID = Guid.NewGuid();
+			obj.isEmpty = this.isEmpty;
+			obj.textBookData = this.textBookData.Clone();
+			return obj;
+		}
+
 		public void RenameTrigger( string oldName, string newName )
 		{
 			if ( triggerName == oldName )

--- a/Models/Trigger.cs
+++ b/Models/Trigger.cs
@@ -68,6 +68,17 @@ namespace JiME
 			isCampaignTrigger = false;
 		}
 
+		public Trigger Clone()
+		{
+			Trigger trig = new Trigger("Copy of " + this.dataName);
+			trig.triggerValue = this.triggerValue;
+			trig.isMultiTrigger = this.isMultiTrigger;
+			trig.isCampaignTrigger = this.isCampaignTrigger;
+			trig.GUID = Guid.NewGuid();
+			trig.isEmpty = this.isEmpty;
+			return trig;
+		}
+
 		void NotifyChange( string prop )
 		{
 			PropertyChanged?.Invoke( this, new PropertyChangedEventArgs( prop ) );

--- a/UserControls/TokenTypeSelector.xaml
+++ b/UserControls/TokenTypeSelector.xaml
@@ -54,7 +54,7 @@
 			<RadioButton x:Name="darkRadio" Content="Darkness" Margin="0,0,20,0" Click="tokenTypeClick"/>
 			<RadioButton x:Name="difficultGroundRadio" Content="Difficult Ground" Margin="0,0,20,0" Click="tokenTypeClick" IsEnabled="False" FontStyle="Italic"/>
 			<RadioButton x:Name="fortifiedRadio" Content="Fortified" Margin="0,0,20,0" Click="tokenTypeClick" IsEnabled="False" FontStyle="Italic"/>
-			<RadioButton x:Name="terrainRadio" Content="Terrain" Margin="0,0,20,0" Click="tokenTypeClick"/>
+			<RadioButton x:Name="terrainRadio" Content="Terrain" Margin="0,0,20,0" Click="tokenTypeClick" IsEnabled="False" FontStyle="Italic"/>
 		</StackPanel>
 		<StackPanel Orientation="Horizontal" Name="personType" Visibility="Collapsed">
 			<TextBlock Text="Person Type:" Style="{StaticResource Heading}" Margin="0,0,10,0"/>

--- a/UserControls/TokenTypeSelector.xaml.cs
+++ b/UserControls/TokenTypeSelector.xaml.cs
@@ -170,7 +170,7 @@ namespace JiME.UserControls
 				isTokenCB.IsEnabled = false;
 			}
 
-			//Special Instructions Visibility
+			//Visibility for various elements
 			if(interaction is ThreatInteraction)
 				threatMessage.Visibility = Visibility.Visible;
 			if (interaction is PersistentTokenInteraction)
@@ -191,12 +191,23 @@ namespace JiME.UserControls
 					skipInteractionCB.FontStyle = FontStyles.Normal;
 				}
 			}
+			if(!scenario.scenarioTypeJourney) //if it's a battle map, enable Terrain
+            {
+				terrainRadio.IsEnabled = true;
+				terrainRadio.FontStyle = FontStyles.Normal;
+            }
 
 			//PersonType and TerrainType Visibility
 			if (interaction.isTokenInteraction && interaction.tokenType == TokenType.Person)
+			{
 				personType.Visibility = Visibility.Visible;
+				if (interaction.personType == PersonType.None) { interaction.personType = PersonType.Human; }
+			}
 			else if (interaction.isTokenInteraction && interaction.tokenType == TokenType.Terrain)
+			{
 				terrainType.Visibility = Visibility.Visible;
+				if (interaction.terrainType == TerrainType.None) { interaction.terrainType = TerrainType.Boulder; }
+			}
 
 			//Persistent Text Visibility
 			persCB.Visibility = (interaction is PersistentInteractionBase) ? Visibility.Visible : Visibility.Collapsed;

--- a/Views/ActivationsEditorWindow.xaml.cs
+++ b/Views/ActivationsEditorWindow.xaml.cs
@@ -108,9 +108,13 @@ namespace JiME.Views
 
 		private void DeleteButton_Click( object sender, RoutedEventArgs e )
 		{
-			MonsterActivationItem mai = ((Button)sender).DataContext as MonsterActivationItem;
-			activations.activations.Remove(mai);
-			activations.RenumberActivations();
+			var ret = MessageBox.Show("Are you sure you want to delete this Enemy Attack Description?\n\nTHIS CANNOT BE UNDONE.", "Delete Enemy Attack Description", MessageBoxButton.YesNo, MessageBoxImage.Question);
+			if (ret == MessageBoxResult.Yes)
+			{
+				MonsterActivationItem mai = ((Button)sender).DataContext as MonsterActivationItem;
+				activations.activations.Remove(mai);
+				activations.RenumberActivations();
+			}
 		}
 
 		void PropChanged( string name )

--- a/Views/Interactions/BranchInteractionWindow.xaml.cs
+++ b/Views/Interactions/BranchInteractionWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace JiME.Views
 			}
 		}
 
-		public BranchInteractionWindow( Scenario s, BranchInteraction inter = null )
+		public BranchInteractionWindow( Scenario s, BranchInteraction inter = null, bool showCancelButton = false )
 		{
 			scenario = s;
 			interaction = inter ?? new BranchInteraction("New Branch Event");
@@ -37,7 +37,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			eventTestRB.IsChecked = interaction.branchTestEvent;
 			triggerTestRB.IsChecked = !interaction.branchTestEvent;

--- a/Views/Interactions/ConditionalInteractionWindow.xaml.cs
+++ b/Views/Interactions/ConditionalInteractionWindow.xaml.cs
@@ -30,13 +30,13 @@ namespace JiME.Views
 			}
 		}
 
-		public ConditionalInteractionWindow( Scenario s, ConditionalInteraction inter = null )
+		public ConditionalInteractionWindow( Scenario s, ConditionalInteraction inter = null, bool showCancelButton = false )
 		{
 			InitializeComponent();
 			DataContext = this;
 
 			scenario = s;
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 			interaction = inter ?? new ConditionalInteraction( "New Conditional Event" );
 
 

--- a/Views/Interactions/DecisionInteractionWindow.xaml.cs
+++ b/Views/Interactions/DecisionInteractionWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace JiME.Views
 			}
 		}
 
-		public DecisionInteractionWindow( Scenario s, DecisionInteraction inter = null )
+		public DecisionInteractionWindow( Scenario s, DecisionInteraction inter = null , bool showCancelButton = false)
 		{
 			scenario = s;
 			interaction = inter ?? new DecisionInteraction("New Decision Event");
@@ -37,7 +37,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )

--- a/Views/Interactions/DialogInteractionWindow.xaml.cs
+++ b/Views/Interactions/DialogInteractionWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace JiME.Views
 			}
 		}
 
-		public DialogInteractionWindow( Scenario s, DialogInteraction inter = null )
+		public DialogInteractionWindow( Scenario s, DialogInteraction inter = null, bool showCancelButton = false )
 		{
 			scenario = s;
 			interaction = inter ?? new DialogInteraction("New Dialog Event");
@@ -37,7 +37,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )

--- a/Views/Interactions/MultiEventWindow.xaml.cs
+++ b/Views/Interactions/MultiEventWindow.xaml.cs
@@ -30,7 +30,7 @@ namespace JiME.Views
 			}
 		}
 
-		public MultiEventWindow( Scenario s, MultiEventInteraction inter = null )
+		public MultiEventWindow( Scenario s, MultiEventInteraction inter = null , bool showCancelButton = false)
 		{
 			scenario = s;
 			interaction = inter ?? new MultiEventInteraction("New Multi-Event");
@@ -38,7 +38,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			triggerRB.IsChecked = interaction.usingTriggers;
 			eventRB.IsChecked = !interaction.usingTriggers;

--- a/Views/Interactions/PersistentInteractionWindow.xaml.cs
+++ b/Views/Interactions/PersistentInteractionWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace JiME.Views
 			}
 		}
 
-		public PersistentInteractionWindow( Scenario s, PersistentTokenInteraction inter = null )
+		public PersistentInteractionWindow( Scenario s, PersistentTokenInteraction inter = null , bool showCancelButton = false)
 		{
 			scenario = s;
 			interaction = inter ?? new PersistentTokenInteraction("New Persistent Event");
@@ -40,7 +40,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			//interactions that are NOT Token Interactions
 			interactionObserver = new ObservableCollection<string>( scenario.interactionObserver.Where( x => x.isTokenInteraction ).Select( x => x.dataName ) );

--- a/Views/Interactions/ReplaceTokenInteractionWindow.xaml.cs
+++ b/Views/Interactions/ReplaceTokenInteractionWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace JiME.Views
 		public ObservableCollection<IInteraction> eventToReplace { get; set; }
 		public ObservableCollection<IInteraction> replaceWith { get; set; }
 
-		public ReplaceTokenInteractionWindow( Scenario s, ReplaceTokenInteraction inter = null )
+		public ReplaceTokenInteractionWindow( Scenario s, ReplaceTokenInteraction inter = null, bool showCancelButton = false )
 		{
 			scenario = s;
 			interaction = inter ?? new ReplaceTokenInteraction("New Replace Token Event");
@@ -41,7 +41,7 @@ namespace JiME.Views
 
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )

--- a/Views/Interactions/RewardInteractionWindow.xaml.cs
+++ b/Views/Interactions/RewardInteractionWindow.xaml.cs
@@ -29,13 +29,13 @@ namespace JiME.Views
 			}
 		}
 
-		public RewardInteractionWindow( Scenario s, RewardInteraction inter = null )
+		public RewardInteractionWindow( Scenario s, RewardInteraction inter = null, bool showCancelButton = false )
 		{
 			InitializeComponent();
 			DataContext = this;
 
 			scenario = s;
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 			interaction = inter ?? new RewardInteraction( "New Reward Event" );
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );

--- a/Views/Interactions/TestInteractionWindow.xaml.cs
+++ b/Views/Interactions/TestInteractionWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace JiME.Views
 			}
 		}
 
-		public TestInteractionWindow( Scenario s, TestInteraction inter = null )
+		public TestInteractionWindow( Scenario s, TestInteraction inter = null, bool showCancelButton = false )
 		{
 			scenario = s;
 			interaction = inter ?? new TestInteraction("New Stat Test");
@@ -37,7 +37,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			mightRB.IsChecked = interaction.testAttribute == Ability.Might;
 			agilityRB.IsChecked = interaction.testAttribute == Ability.Agility;

--- a/Views/Interactions/TextInteractionWindow.xaml.cs
+++ b/Views/Interactions/TextInteractionWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace JiME.Views
 			}
 		}
 
-		public TextInteractionWindow( Scenario s, TextInteraction inter = null )
+		public TextInteractionWindow( Scenario s, TextInteraction inter = null, bool showCancelButton = false )
 		{
 			scenario = s;
 			interaction = inter ?? new TextInteraction("New Text Event");
@@ -37,7 +37,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )

--- a/Views/Interactions/ThreatInteractionWindow.xaml.cs
+++ b/Views/Interactions/ThreatInteractionWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace JiME.Views
 			}
 		}
 
-		public ThreatInteractionWindow( Scenario s, ThreatInteraction inter = null )
+		public ThreatInteractionWindow( Scenario s, ThreatInteraction inter = null , bool showCancelButton = false)
 		{
 			scenario = s;
 			interaction = inter ?? new ThreatInteraction("New Threat Event");
@@ -47,7 +47,7 @@ namespace JiME.Views
 			InitializeComponent();
 			DataContext = this;
 
-			cancelButton.Visibility = inter == null ? Visibility.Visible : Visibility.Collapsed;
+			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -244,8 +244,12 @@ namespace JiME.Views
 
 		private void DeleteButton_Click( object sender, RoutedEventArgs e )
 		{
-			Monster m = ( (Button)sender ).DataContext as Monster;
-			interaction.monsterCollection.Remove( m );
+			var ret = MessageBox.Show("Are you sure you want to delete this Scripted Enemy?\n\nTHIS CANNOT BE UNDONE.", "Delete Scripted Enemy", MessageBoxButton.YesNo, MessageBoxImage.Question);
+			if (ret == MessageBoxResult.Yes)
+			{
+				Monster m = ((Button)sender).DataContext as Monster;
+				interaction.monsterCollection.Remove(m);
+			}
 		}
 
 		void PropChanged( string name )

--- a/Views/ScenarioWindow.xaml.cs
+++ b/Views/ScenarioWindow.xaml.cs
@@ -372,7 +372,6 @@ namespace JiME.Views
 					}
 					else
 					{
-						//scenario.chapterObserver[0].ToBattleTile();
 						scenario.chapterObserver[0].ToSquareTile();
 						scenario.AddDefaultTerrainInteractions();
 					}

--- a/Views/TileEditorWindow.xaml.cs
+++ b/Views/TileEditorWindow.xaml.cs
@@ -138,17 +138,26 @@ namespace JiME.Views
 					selected.Rotate(1, canvas );
 				else if ( e.Key == Key.Delete )
 				{
-					RemoveTile(selected, true);
-					selected = null;
-					//sort list
-					TileSorter sorter = new TileSorter();
-					List<int> foo = scenario.globalTilePool.ToList();
-					foo.Sort( sorter );
-					scenario.globalTilePool.Clear();
-					foreach ( int s in foo )
-						scenario.globalTilePool.Add( s );
-					tilePool.SelectedIndex = 0;
+					DeleteTileAction();
 				}
+			}
+		}
+
+		private void DeleteTileAction()
+		{
+			var ret = MessageBox.Show("Are you sure you want to delete this Tile?\n\nALL ITS TOKENS WILL BE DELETED.", "Delete Tile", MessageBoxButton.YesNo, MessageBoxImage.Question);
+			if (ret == MessageBoxResult.Yes)
+			{
+				RemoveTile(selected, true);
+				selected = null;
+				//sort list
+				TileSorter sorter = new TileSorter();
+				List<int> foo = scenario.globalTilePool.ToList();
+				foo.Sort(sorter);
+				scenario.globalTilePool.Clear();
+				foreach (int s in foo)
+					scenario.globalTilePool.Add(s);
+				tilePool.SelectedIndex = 0;
 			}
 		}
 
@@ -190,16 +199,7 @@ namespace JiME.Views
 		{
 			if ( selected != null )
 			{
-				RemoveTile(selected, true);
-				selected = null;
-				//sort list
-				TileSorter sorter = new TileSorter();
-				List<int> foo = scenario.globalTilePool.ToList();
-				foo.Sort( sorter );
-				scenario.globalTilePool.Clear();
-				foreach ( int s in foo )
-					scenario.globalTilePool.Add( s );
-				tilePool.SelectedIndex = 0;
+				DeleteTileAction();
 			}
 		}
 

--- a/Views/TriggerEditorWindow.xaml.cs
+++ b/Views/TriggerEditorWindow.xaml.cs
@@ -58,6 +58,28 @@ namespace JiME.Views
 			isNew = true;
 		}
 
+		public TriggerEditorWindow(Scenario s, Trigger trigger, bool showCancelButton = false)
+        {
+			InitializeComponent();
+			DataContext = this;
+			scenario = s;
+			nameTB.Text = trigger.dataName;
+			nameTB.SelectAll();
+			multiCB.IsChecked = trigger.isMultiTrigger;
+			campaignCB.IsChecked = trigger.isCampaignTrigger;
+
+			if (scenario.projectType == ProjectType.Standalone)
+				campaignCB.Visibility = Visibility.Collapsed;
+
+			if (campaignCB.IsChecked == true)
+			{
+				nameTB.IsEnabled = false;
+				multiCB.IsEnabled = false;
+			}
+
+			isNew = true;
+		}
+
 		private void OkButton_Click( object sender, RoutedEventArgs e )
 		{
 			triggerName = nameTB.Text.Trim();


### PR DESCRIPTION
Delete confirmation dialogs for: Objectives, Events, Triggers, Enemy Attack Groups, Scripted Enemies, and Tiles

Duplicate buttons have been added for: Objectives, Events, Triggers. These duplicate (make a copy of) the underlying objects.