### PR TITLE
Updates to token interaction groups and user interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Removed
+
+## [v0.25]
+
+### Added
 - Added graph based visualization of the Scenario inside the main Scenario editor Window. 
   - The visualization shows all the major Scenario entities and trigger relations between them.
   - The visualization nodes are clickable to open the editor dialogs for the different entities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ All notable changes to this project will be documented in this file.
     It can still be used for testing purposes or as a starting point for generating a Scenatio manually.
 - Added "Skins" and "Languages" to the group of folders to exclude from treating as a Campaign folder.
 - Added new text field to TokenTypeSelector, "Token Interaction Text", that allows custom text to display on token interaction button instead of Search, Threat, etc.
+- Checkbox on events that can be part of a token interaction group (e.g. GRP1) to allow an event to be used more than once
 
 ### Changed
 - Changed a lot of names in text and variable names to move away from names that are probably trademarked or could be.
 - Disabled the ability to modify the default enemy attack descriptions. Authors are required to make a copy in order to modify it.
 - When a scenario is saved out, it only includes Monster Activations that are custom, not the default Activations
+- Both fixed and random tokens can be added to both fixed and random tile blocks
 
 ### Removed
 - Removed enemy attack descriptions that aren't directly related to the enemy figurines. Relocated some enemy attack descriptions.

--- a/Common/Common.cs
+++ b/Common/Common.cs
@@ -82,6 +82,7 @@ namespace JiME
 		PersonType personType { get; set; }
 
 		TerrainType terrainType { get; set; }
+		bool isReusable { get; set; }
 	}
 
 	class Debug
@@ -248,7 +249,7 @@ namespace JiME
 		/// Update this number every time the file format changes with new features
 		/// </summary>
 		public static string formatVersion = "1.13";
-		public static string appVersion = "0.23";
+		public static string appVersion = "0.25";
 		public static Dictionary<int, BaseTileData> tileDictionary { get; set; } = new Dictionary<int, BaseTileData>();
 		public static Dictionary<int, BaseTileData> tileDictionaryB { get; set; } = new Dictionary<int, BaseTileData>();
 		public static int tolerance = 25;

--- a/Models/Interaction Events/InteractionBase.cs
+++ b/Models/Interaction Events/InteractionBase.cs
@@ -6,7 +6,7 @@ namespace JiME
 	public abstract class InteractionBase : IInteraction, INotifyPropertyChanged
 	{
 		string _dataName, _triggerName, _triggerAfterName, _tokenInteractionText;
-		bool _isTokenInteraction;
+		bool _isTokenInteraction, _isReusable;
 		int _loreReward, _xpReward, _threatReward;
 		TokenType _tokenType;
 		PersonType _personType;
@@ -30,6 +30,7 @@ namespace JiME
 			interact.eventBookData = this.eventBookData.Clone();
 			interact.interactionType = this.interactionType;
 			interact.tokenInteractionText = this.tokenInteractionText;
+			interact.isReusable = this.isReusable;
 		}
 
 		public string dataName
@@ -132,6 +133,16 @@ namespace JiME
 				NotifyPropertyChanged( "threatReward" );
 			}
 		}
+		public bool isReusable
+		{
+			get => _isReusable;
+			set
+			{
+				_isReusable = value;
+				NotifyPropertyChanged("isReusable");
+			}
+		}
+
 
 		public InteractionType interactionType { get; set; }
 
@@ -154,6 +165,7 @@ namespace JiME
 			eventBookData.pages.Add( "Default Event Text.\n\nThis text is shown after the Event is triggered. Use it to tell about the actual event that has been triggered Example: Describe an Enemy Threat, present a Test, describe a Decision, etc." );
 			loreReward = xpReward = threatReward = 0;
 			tokenInteractionText = "";
+			isReusable = false;
 		}
 
 		public void NotifyPropertyChanged( string propName )

--- a/Models/Interaction Events/NoneInteraction.cs
+++ b/Models/Interaction Events/NoneInteraction.cs
@@ -9,14 +9,15 @@ namespace JiME
 
 		public static NoneInteraction EmptyInteraction()
 		{
-			NoneInteraction empty = new NoneInteraction( "None" )
+			NoneInteraction empty = new NoneInteraction("None")
 			{
 				dataName = "None",
 				isEmpty = true,
 				tokenType = TokenType.None,
 				personType = PersonType.None,
 				terrainType = TerrainType.None,
-				isTokenInteraction = false
+				isTokenInteraction = false,
+				isReusable = false
 			};
 			return empty;
 		}

--- a/Models/Interaction Events/PersistentTokenInteraction.cs
+++ b/Models/Interaction Events/PersistentTokenInteraction.cs
@@ -29,6 +29,7 @@ namespace JiME
 			alternativeTextTrigger = "None";
 			eventToActivate = "None";
 			isTokenInteraction = true;
+			isReusable = false;
 		}
 
 		public PersistentTokenInteraction Clone()

--- a/Views/HelpWindow.xaml
+++ b/Views/HelpWindow.xaml
@@ -27,6 +27,7 @@
 						<TextBlock Style="{StaticResource SubText}" TextWrapping="Wrap" Text="2) Select a Token Type associated with this Token Interaction Event."/>
 						<TextBlock Style="{StaticResource SubText}" TextWrapping="Wrap" Text="3) At the end of the Event Name, use 'GRP#' to place it into an Interaction Group, where # uniquely identifies that group."/>
 						<TextBlock Style="{StaticResource SubText}" TextWrapping="Wrap" Text="4) Use this same GRP# naming convention to add other Token Interactions you create into this group."/>
+						<TextBlock Style="{StaticResource SubText}" TextWrapping="Wrap" Text="5) (optionally) click the checkbox [x] This grouped Event can be used more than once"/>
 						<TextBlock Margin="0,10,0,0" Style="{StaticResource SubText}" TextWrapping="Wrap" Text="For example, two different Events named 'light fire GRP2' and 'orc squad GRP2' will put both of the Events into an Interaction Group with the name 'GRP2'. You can put as many Events into groups as you wish."/>
 						<TextBlock Style="{StaticResource SubText}" Margin="0,10,0,0" TextWrapping="Wrap" Text="NOTE: The Token Interactions in the group don't have to be of the same type. They can be a combination of any of the Event types (Text, Enemies, Stat Tests, etc)." FontStyle="Italic"/>
 					</StackPanel>
@@ -52,7 +53,7 @@
 							Example: Using Tiles 201 and 202, we have 4 spaces available, and we're not using any fixed Tokens. Let's say we assign an Interaction Group to this Tile Block with 6 different Events in it. We can use a maximum of 4 of those 6 Events because there are only 4 spaces available on the Tiles we're using. However, we only want 2 of those 6 Events to randomly spawn Tokens on these Tiles, so we enter 2 into the text box. During the game, the Companion App will randomly choose 2 Events out of the Group and randomly spawn their Token on the tiles. The other 4 Events are discarded.
 						</TextBlock>
 						<TextBlock Style="{StaticResource SubText}" TextWrapping="Wrap" Margin="0,10,0,0">
-							<Bold><Italic>CAUTION</Italic></Bold>: If you assign the same Token Interaction Group to more than one Block, the same Events could be seen by players more than once, causing confusion. On the other hand, Events can be created that are generic enough to appear more than once by design. A good example of this would be creating a Group with 5 different enemy Threat Events in it. This Group can be used over and over to randomly spawn one of the Threats in the Group when it's triggered.
+							<Bold><Italic>CAUTION</Italic></Bold>: You can assign the same Token Interaction Group to more than one Block. Once an Event token has been placed in one Tile Block, it will not be placed in another Tile BLock unless you check the box "This grouped Event can be used more than once". Only do this if you create Events that are generic enough to appear more than once by design. A good example of this might be a Threat Events with enemies that can appear on various places in the map. Or perhaps natural hazards like avalanches or cave-ins that could occur in multiple locations. Or a healing herb that appears in random spots and instructs the player to add a token to their Hero card.
 						</TextBlock>
 					</StackPanel>
 				</Border>

--- a/Views/Interactions/BranchInteractionWindow.xaml
+++ b/Views/Interactions/BranchInteractionWindow.xaml
@@ -55,15 +55,19 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
+
 						</UniformGrid>
 					</Border>
 

--- a/Views/Interactions/BranchInteractionWindow.xaml.cs
+++ b/Views/Interactions/BranchInteractionWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			eventTestRB.IsChecked = interaction.branchTestEvent;
 			triggerTestRB.IsChecked = !interaction.branchTestEvent;
@@ -191,12 +192,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 	}
 }

--- a/Views/Interactions/DecisionInteractionWindow.xaml
+++ b/Views/Interactions/DecisionInteractionWindow.xaml
@@ -55,14 +55,18 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/DecisionInteractionWindow.xaml.cs
+++ b/Views/Interactions/DecisionInteractionWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -175,12 +176,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 	}
 }

--- a/Views/Interactions/DialogInteractionWindow.xaml
+++ b/Views/Interactions/DialogInteractionWindow.xaml
@@ -55,14 +55,17 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/DialogInteractionWindow.xaml.cs
+++ b/Views/Interactions/DialogInteractionWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -171,12 +172,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		private void addMainTriggerButton_Click( object sender, RoutedEventArgs e )

--- a/Views/Interactions/MultiEventWindow.xaml
+++ b/Views/Interactions/MultiEventWindow.xaml
@@ -56,14 +56,17 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/MultiEventWindow.xaml.cs
+++ b/Views/Interactions/MultiEventWindow.xaml.cs
@@ -39,6 +39,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			triggerRB.IsChecked = interaction.usingTriggers;
 			eventRB.IsChecked = !interaction.usingTriggers;
@@ -151,12 +152,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		void PropChanged( string name )

--- a/Views/Interactions/PersistentInteractionWindow.xaml
+++ b/Views/Interactions/PersistentInteractionWindow.xaml
@@ -52,14 +52,17 @@
 								</StackPanel>-->
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/PersistentInteractionWindow.xaml.cs
+++ b/Views/Interactions/PersistentInteractionWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			//interactions that are NOT Token Interactions
 			interactionObserver = new ObservableCollection<string>( scenario.interactionObserver.Where( x => x.isTokenInteraction ).Select( x => x.dataName ) );
@@ -196,12 +197,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		private void editAltButton_Click( object sender, RoutedEventArgs e )

--- a/Views/Interactions/ReplaceTokenInteractionWindow.xaml
+++ b/Views/Interactions/ReplaceTokenInteractionWindow.xaml
@@ -60,14 +60,17 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/ReplaceTokenInteractionWindow.xaml.cs
+++ b/Views/Interactions/ReplaceTokenInteractionWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -226,12 +227,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 	}
 }

--- a/Views/Interactions/TestInteractionWindow.xaml
+++ b/Views/Interactions/TestInteractionWindow.xaml
@@ -54,14 +54,17 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/TestInteractionWindow.xaml.cs
+++ b/Views/Interactions/TestInteractionWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			mightRB.IsChecked = interaction.testAttribute == Ability.Might;
 			agilityRB.IsChecked = interaction.testAttribute == Ability.Agility;
@@ -220,12 +221,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		private void mightRB2_Click( object sender, RoutedEventArgs e )

--- a/Views/Interactions/TextInteractionWindow.xaml
+++ b/Views/Interactions/TextInteractionWindow.xaml
@@ -55,14 +55,17 @@
 								<TextBlock Text="Rewards are given after the Event is finished activating." Style="{StaticResource SubText}" Margin="0,5,0,0"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/TextInteractionWindow.xaml.cs
+++ b/Views/Interactions/TextInteractionWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -158,12 +159,24 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
-				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
-			else
-				groupInfo.Text = "This Event is in the following group: None";
+			updateUIForEventGroup();
 		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
+				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
+			else
+			{
+				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
+		}
+
 	}
 }

--- a/Views/Interactions/ThreatInteractionWindow.xaml
+++ b/Views/Interactions/ThreatInteractionWindow.xaml
@@ -55,14 +55,17 @@
 								<TextBlock Text="For Threat Events, rewards are only given after all Enemies have been defeated." Style="{StaticResource SubText}" Margin="0,5,0,0" VerticalAlignment="Center" TextWrapping="Wrap"/>
 							</StackPanel>
 
-							<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-								<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
-									<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
-								</Button>
-								<StackPanel Margin="10,0,0,0">
-									<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
-									<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+							<StackPanel Orientation="Vertical">
+								<StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+									<Button x:Name="groupHelp" Background="#FFC98800" Click="groupHelp_Click" Width="32" Height="32" Margin="10,0,0,0">
+										<Image Source="/JiME;component/Assets/help.png" Stretch="Uniform"/>
+									</Button>
+									<StackPanel Margin="10,0,0,0">
+										<TextBlock Style="{StaticResource SubText}" Text="You can place this Event into a Random Interaction Group." TextWrapping="Wrap" VerticalAlignment="Center" Width="290"/>
+										<TextBlock x:Name="groupInfo" Margin="0,5,0,0" Style="{StaticResource SubText}" Text="This Event is in the following group: None"/>
+									</StackPanel>
 								</StackPanel>
+								<CheckBox x:Name="isReusableCB" Margin="32,20,0,0" Content="This grouped Event can be used more than once" Foreground="White" IsChecked="{Binding interaction.isReusable}" Visibility="Visible" VerticalAlignment="Top"/>
 							</StackPanel>
 						</UniformGrid>
 					</Border>

--- a/Views/Interactions/ThreatInteractionWindow.xaml.cs
+++ b/Views/Interactions/ThreatInteractionWindow.xaml.cs
@@ -48,6 +48,7 @@ namespace JiME.Views
 			DataContext = this;
 
 			cancelButton.Visibility = (inter == null || showCancelButton) ? Visibility.Visible : Visibility.Collapsed;
+			updateUIForEventGroup();
 
 			isThreatTriggered = scenario.threatObserver.Any( x => x.triggerName == interaction.dataName );
 			if ( isThreatTriggered )
@@ -266,12 +267,23 @@ namespace JiME.Views
 		private void nameTB_TextChanged( object sender, TextChangedEventArgs e )
 		{
 			interaction.dataName = ( (TextBox)sender ).Text;
-			Regex rx = new Regex( @"\sGRP\d+$" );
-			MatchCollection matches = rx.Matches( interaction.dataName );
-			if ( matches.Count > 0 )
+			updateUIForEventGroup();
+		}
+
+		private void updateUIForEventGroup()
+		{
+			Regex rx = new Regex(@"\sGRP\d+$");
+			MatchCollection matches = rx.Matches(interaction.dataName);
+			if (matches.Count > 0)
+			{
 				groupInfo.Text = "This Event is in the following group: " + matches[0].Value.Trim();
+				isReusableCB.Visibility = Visibility.Visible;
+			}
 			else
+			{
 				groupInfo.Text = "This Event is in the following group: None";
+				isReusableCB.Visibility = Visibility.Collapsed;
+			}
 		}
 
 		private void addDefeatedTriggerButton_Click( object sender, RoutedEventArgs e )

--- a/Views/TileEditorWindow.xaml.cs
+++ b/Views/TileEditorWindow.xaml.cs
@@ -79,8 +79,10 @@ namespace JiME.Views
 				}
 			}
 
-			editTokenButton.IsEnabled = !chapter.usesRandomGroups;
-			disabledMessage.Visibility = chapter.usesRandomGroups ? Visibility.Visible : Visibility.Collapsed;
+			//editTokenButton.IsEnabled = !chapter.usesRandomGroups;
+			//disabledMessage.Visibility = chapter.usesRandomGroups ? Visibility.Visible : Visibility.Collapsed;
+			editTokenButton.IsEnabled = true;
+			disabledMessage.Visibility = Visibility.Collapsed;
 			//SourceInitialized += ( x, y ) =>
 			//{
 			//	this.HideMinimizeAndMaximizeButtons();

--- a/Views/TilePoolEditorWindow.xaml.cs
+++ b/Views/TilePoolEditorWindow.xaml.cs
@@ -206,7 +206,7 @@ namespace JiME.Views
 				sideA.IsChecked = selected.tileSide == "A";
 				sideB.IsChecked = selected.tileSide == "B";
 				sideRandom.IsChecked = selected.tileSide == "Random";
-				if ( !chapter.usesRandomGroups )
+				//if ( !chapter.usesRandomGroups )
 					tokenEditButton.IsEnabled = !sideRandom.IsChecked.Value;
 				ShowExploreStatus();
 			}


### PR DESCRIPTION
Allow both fixed and random token events to be assigned to fixed or random tile blocks at any time.

Add checkbox to events that can be part of token interaction groups. Checkbox sets the isReusable property to true, which allows the token event to be placed in multiple tile blocks instead of just used once.